### PR TITLE
load-objects with order param

### DIFF
--- a/content/edweb.xql
+++ b/content/edweb.xql
@@ -267,8 +267,8 @@ declare function edweb:add-link-to-prev-object(
     $model as map(*)
 ) 
 {
-    let $labelled-ids := $model?order?id (: [?label-pos=1] :)
     let $object-type := $model?object-type
+    let $labelled-ids := if ($object-type = ("briefe", "documents")) then $model?order?id else $model?all[?label-pos=1]?id
     let $position := index-of( $labelled-ids, $model?id )
     return
         if ($labelled-ids[$position -1]) 
@@ -284,8 +284,8 @@ declare function edweb:add-link-to-next-object(
     $model as map(*)
 ) 
 {
-    let $labelled-ids := $model?order?id (: [?label-pos=1] :)
     let $object-type := $model?object-type
+    let $labelled-ids := if ($object-type = ("briefe", "documents")) then $model?order?id else $model?all[?label-pos=1]?id
     let $position := index-of( $labelled-ids, $model?id )
     return
         if ($labelled-ids[$position +1]) 

--- a/content/edweb.xql
+++ b/content/edweb.xql
@@ -838,7 +838,8 @@ declare %templates:wrap function edweb:load-inner-navigation(
  :)
 declare %templates:wrap function edweb:load-objects(
     $node as node(),
-    $model as map(*)
+    $model as map(*),
+    $order as xs:string?
 ) as map(*)
 {
     let $object-type := request:get-attribute("object-type")
@@ -869,12 +870,12 @@ declare %templates:wrap function edweb:load-objects(
         ))
 
     let $filter-params := edweb:params-load((map:keys($filters)))
-    let $all-objects := edwebcontroller:api-get("/api/"||$object-type||"?show=all&amp;order=label")
+    let $all-objects := edwebcontroller:api-get("/api/"||$object-type||"?show=all&amp;order="||$order)
     let $filtered-objects :=
         if (edweb:params-insert($filter-params) != "")
         then
             edwebcontroller:api-get(
-                "/api/"||$object-type||"?show=list&amp;order=label&amp;"
+                "/api/"||$object-type||"?show=list&amp;order="||$order||"&amp;"
                 ||edweb:params-insert($filter-params)
             )
         else $all-objects

--- a/content/edweb.xql
+++ b/content/edweb.xql
@@ -1641,7 +1641,19 @@ declare function edweb:template-transform-current(
                 return element param {
                     attribute name { $param/@name },
                     attribute value { $param/@value }
-            }
+            },
+            if (not($resource))
+            then
+                (let $params := if ($view != "")
+                                then tokenize($model?views?($view)?params, ' ')
+                                else tokenize($model?views?*[?n=1]?params, ' ')
+                return for $param in $params
+                        return element  param {
+                                            attribute name { "view" },
+                                            attribute value { $param }
+                                        }
+                )
+            else ()
         } </parameters>
     let $result :=
         try {

--- a/content/edweb.xql
+++ b/content/edweb.xql
@@ -267,7 +267,7 @@ declare function edweb:add-link-to-prev-object(
     $model as map(*)
 ) 
 {
-    let $labelled-ids := $model?all[?label-pos=1]?id
+    let $labelled-ids := $model?order?id (: [?label-pos=1] :)
     let $object-type := $model?object-type
     let $position := index-of( $labelled-ids, $model?id )
     return
@@ -284,7 +284,7 @@ declare function edweb:add-link-to-next-object(
     $model as map(*)
 ) 
 {
-    let $labelled-ids := $model?all[?label-pos=1]?id
+    let $labelled-ids := $model?order?id (: [?label-pos=1] :)
     let $object-type := $model?object-type
     let $position := index-of( $labelled-ids, $model?id )
     return
@@ -707,6 +707,9 @@ declare %templates:wrap function edweb:load-current-object(
             request:get-attribute("id")
     let $map := edwebcontroller:api-get("/api/"||$object-type||"/"||$object-id||"?output=json-xml")
     let $current-doc := map:entry("current-doc", $map?xml)
+    let $order-by := if ($object-type = ("briefe", "documents")) then "date" else "label"
+    let $all-objects := edwebcontroller:api-get("/api/"||$object-type||"?show=all&amp;order="||$order-by)
+    let $model := map:put($model, "order", $all-objects)
     return
         map:merge(($model, $map, $current-doc))
 };


### PR DESCRIPTION
Add optional parameter "order" to the function edweb:load-objects in order to be able to sort the list-view of objects based on their defined filter-properties.