### PR TITLE
Update edweb-api.xql

### DIFF
--- a/content/edweb-api.xql
+++ b/content/edweb-api.xql
@@ -264,7 +264,7 @@ declare function edwebapi:load-map-from-cache(
 
     let $load-map :=
         (: Block caching if cache is younger than 1 min :)
-        if ($cache-exists and (current-dateTime() < xs:dateTime($load-map?date-time) + xs:dayTimeDuration("PT1M")))
+        if ($cache-exists and (xs:dateTime(current-dateTime()) < xs:dateTime($load-map?date-time) + xs:dayTimeDuration("PT1M")))
         then $load-map
         (: Start caching if hard-reload is set :)
         else if ($hard-reload)


### PR DESCRIPTION
Edited function "load-map-from-cache" in order to prevent "Type error: cannot compare xs:dateTimeStamp to xs:dateTime". 

This change will be irrelvant for the main branch, as the module has been rewritten and uses xmldb:last-modified instead (which returns xs:dateTime).