### PR TITLE
Update function order-items

### DIFF
--- a/content/edweb-api.xql
+++ b/content/edweb-api.xql
@@ -1293,7 +1293,7 @@ declare function edwebapi:order-items(
                                 $item?filter,
                                 map:merge((
                                     for $fk in map:keys($item?label-filter) return
-                                        map:entry($fk, $item?label-filter?($fk)?*[$pos])
+                                        map:entry($fk, $item?label-filter?($fk)?*[$label])
                                 ))
                             ))
                         ),


### PR DESCRIPTION
When sorting objects by label, get the values for the label-filter properties not based on the position of the object label but on its value.

Example:
![Beispiel_FehlerInSortierung](https://github.com/user-attachments/assets/17ff3741-8b28-447e-a800-0a10c8fa7bb2)

A person entry has a regular name "Leibowitz, Ellen" and an alternative name "Adler, Ellen".
In the entry for "Adler, Ellen" inside the model, the alphabet filter property has the wrong value "L" (and vice versa for "Leibowitz, Ellen") because the property is created based on the "label-filter" map and the position of the label in the "labels" array. "Adler, Ellen" is second position in the "labels" array, in the "label-filter" properties however, the key on second position holds the values for "Leibowitz, Ellen". Instead of getting the values based on their position in the "labels" array, get them based on their key, which holds the label.