### PR TITLE
Wrong label-filter values with alt-Names

### DIFF
--- a/content/edweb-api.xql
+++ b/content/edweb-api.xql
@@ -1293,7 +1293,7 @@ declare function edwebapi:order-items(
                                 $item?filter,
                                 map:merge((
                                     for $fk in map:keys($item?label-filter) return
-                                        map:entry($fk, $item?label-filter?($fk)?*[$label])
+                                        map:entry($fk, $item?label-filter?($fk)?($label))
                                 ))
                             ))
                         ),


### PR DESCRIPTION
When sorting objects by label, get the values for the label-filter properties not based on the position of the object label but on its string value.

![Beispiel_FehlerInSortierung](https://github.com/user-attachments/assets/1be3b399-1c2e-4edb-9561-498bc53d3c25)

A person entry has a regular name "Leibowitz, Ellen" and an alternative name "Adler, Ellen".
In the entry for "Adler, Ellen" inside the model, the alphabet filter property has the wrong value "L" (and vice versa for "Leibowitz, Ellen") because the property is created based on the "label-filter" map and the position of the label in the "labels" array. "Adler, Ellen" is second position in the "labels" array, in the "label-filter" properties however, the key on second position holds the values for "Leibowitz, Ellen". Instead of getting the values based on their position in the "labels" array, get them based on their key, which holds the label.