### PR TITLE
compare labels before selecting values from "label-filter" properties

### DIFF
--- a/content/edweb-api.xql
+++ b/content/edweb-api.xql
@@ -866,7 +866,7 @@ declare function edwebapi:eval-filters-for-object(
                             map:merge((
                             for $fo in $object?labels?*
                             return
-                                map:entry($fo, array {ft:field($object-xml-or-json, $object-type||"---label---"||$f/@xml:id/string()) ! substring-after(., $fo||"---") ! (if (. != "") then . else ())})
+                                map:entry($fo, array {filter(ft:field($object-xml-or-json, $object-type||"---label---"||$f/@xml:id/string()), function($item) {$fo eq substring-before($item, "---")}) ! substring-after(., $fo||"---") ! (if (. != "") then . else ())})
                             ))
                         )
                 )))

--- a/content/edweb-api.xql
+++ b/content/edweb-api.xql
@@ -1293,7 +1293,7 @@ declare function edwebapi:order-items(
                                 $item?filter,
                                 map:merge((
                                     for $fk in map:keys($item?label-filter) return
-                                        map:entry($fk, $item?label-filter?($fk)?*[$label])
+                                        map:entry($fk, $item?label-filter?($fk)?($label))
                                 ))
                             ))
                         ),


### PR DESCRIPTION
A bug happens with label-filters when there is an object which has two labels and the string of one label is contained in the other label.

Example:
Person entry with labels "Scheu-Riesz, Helene" und "Riesz, Helene" as regular and alternative name.

Bug:
When using alphabetical filtering, "Riesz, Helene" has letters "R" and "S" as filter values

Reason:
Inside the function "edwebapi:eval-filters-for-object" the "label-filter" values are added to the model. During this process, function ft:field produces the following result:

![Riesz_Fehler](https://github.com/user-attachments/assets/b1f2d342-268c-4241-966c-8a80710a8c52)
=> result of function ft:field, BEFORE the substring-function is applied!

For each string in the array, the substring after "[label]---" is then selected as filter value. In case of the alphabet property for "Riesz, Helene", the substring "Riesz, Helene---" is found in both array entries and so both letters "S" and "R" are selected as alphabetical filter values for "Riesz, Helene".

Solution:
Additional filtering of the returned sequence from fn:field based on the exact label, so that only the correct string is returned.